### PR TITLE
Add dumping/reading Proxy Roles to/from proxy_roles header

### DIFF
--- a/src/Products/PythonScripts/PythonScript.py
+++ b/src/Products/PythonScripts/PythonScript.py
@@ -466,6 +466,8 @@ class PythonScript(Script, Historical, Cacheable):
                     self.title = v
                 elif k == 'parameters':
                     self._params = v
+                elif k == 'proxy_roles':
+                    self.manage_proxy(v.split(','))
                 elif k[:5] == 'bind ':
                     bindmap[_nice_bind_names[k[5:]]] = v
                     bup = 1
@@ -492,6 +494,7 @@ class PythonScript(Script, Historical, Cacheable):
         m = {
             'title': self.title,
             'parameters': self._params,
+            'proxy_roles': ','.join(self._proxy_roles)
         }
         bindmap = self.getBindingAssignments().getAssignedNames()
         for k, v in _nice_bind_names.items():


### PR DESCRIPTION
Add dumping/reading Proxy Roles to/from proxy_roles header. Roles represented as comma-separated list.

Example:

```
## Script (Python) "test1"
##bind container=container
##bind context=context
##bind namespace=
##bind script=script
##bind subpath=traverse_subpath
##parameters=
##proxy_roles=Role1,Role2
##title=
##
return "OK"
```