### PR TITLE
Force recompilation of scripts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - 3.5
     - 3.6
 install:
+    - pip install -U six==$(curl $(awk '$1 ==  "extends" {print $3}' buildout.cfg) 2>/dev/null | awk '$1 == "six" {print $3}')
     - pip install coverage coveralls
     - python bootstrap.py
     - bin/buildout

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-4.2 (unreleased)
-----------------
+4.1.1 (unreleased)
+------------------
 
-- Nothing changed yet.
+- Force recompilation of scripts as the compiled code is now stored
+  on `__code__` instead of `func_code`.
 
 
 4.1 (2017-06-19)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,8 +1,7 @@
 [buildout]
-extends = 
-    https://zopefoundation.github.io/Zope/releases/4.0a6/versions-prod.cfg
+extends = https://zopefoundation.github.io/Zope/releases/4.0b2/versions-prod.cfg
 develop = .
-parts = 
+parts =
     interpreter
     test
     tox

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='Products.PythonScripts',
-      version='4.2.dev0',
+      version='4.1.1.dev0',
       url='https://github.com/zopefoundation/Products.PythonScripts',
       license='ZPL 2.1',
       description="Provides support for restricted execution of Python "

--- a/src/Products/PythonScripts/PythonScript.py
+++ b/src/Products/PythonScripts/PythonScript.py
@@ -58,7 +58,7 @@ Python_magic = imp.get_magic()
 del imp
 
 # This should only be incremented to force recompilation.
-Script_magic = 3
+Script_magic = 4
 _log_complaint = (
     'Some of your Scripts have stale code cached.  Since Zope cannot'
     ' use this code, startup will be slightly slower until these Scripts'


### PR DESCRIPTION
The compiled code is now stored on `__code__` instead of `func_code`.
Without recompilation the scripts break because `__code__` is `None` which is not expected by ZPublisher/mapply.py

See also zopefoundation/Zope#172.