### PR TITLE
Remove bogus security declarations

### DIFF
--- a/src/Products/PythonScripts/PythonScript.py
+++ b/src/Products/PythonScripts/PythonScript.py
@@ -414,8 +414,10 @@ class PythonScript(Script, Historical, Cacheable):
     security.declareProtected(
         'Change Python Scripts',
         'PUT', 'manage_FTPput', 'write',
-        'manage_historyCopy',
-        'manage_beforeHistoryCopy', 'manage_afterHistoryCopy')
+        #'manage_historyCopy',
+        #'manage_beforeHistoryCopy',
+        #'manage_afterHistoryCopy',
+    )
 
     def PUT(self, REQUEST, RESPONSE):
         """ Handle HTTP PUT requests """

--- a/src/Products/PythonScripts/PythonScript.py
+++ b/src/Products/PythonScripts/PythonScript.py
@@ -413,11 +413,7 @@ class PythonScript(Script, Historical, Cacheable):
 
     security.declareProtected(
         'Change Python Scripts',
-        'PUT', 'manage_FTPput', 'write',
-        #'manage_historyCopy',
-        #'manage_beforeHistoryCopy',
-        #'manage_afterHistoryCopy',
-    )
+        'PUT', 'manage_FTPput', 'write')
 
     def PUT(self, REQUEST, RESPONSE):
         """ Handle HTTP PUT requests """


### PR DESCRIPTION
 Fixes #13

Removing these declarations is healthy, because calling `manage_changeProperties()` breaks on PythonScripts when the declarations are still in place.
Therefore, I'd recommend removing them.