### PR TITLE
Drop support for historical versions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Changelog
 - Update HTML code of ZMI for Bootstrap ZMI.
   (`#16 <https://github.com/zopefoundation/Products.PythonScripts/pull/16>`_)
 
+- Drop support for historical versions which no longer exist since Zope 4.0a2.
+
 
 4.1 (2017-06-19)
 ----------------

--- a/src/Products/PythonScripts/PythonScript.py
+++ b/src/Products/PythonScripts/PythonScript.py
@@ -35,8 +35,6 @@ from App.Common import package_home
 from App.Dialogs import MessageDialog
 from App.special_dtml import DTMLFile
 from OFS.Cache import Cacheable
-from OFS.History import Historical
-from OFS.History import html_diff
 from OFS.SimpleItem import SimpleItem
 from RestrictedPython import compile_restricted_function
 from Shared.DC.Scripts.Script import BindingsUI
@@ -97,7 +95,7 @@ def manage_addPythonScript(self, id, REQUEST=None, submit=None):
     return ''
 
 
-class PythonScript(Script, Historical, Cacheable):
+class PythonScript(Script, Cacheable):
     """Web-callable scripts written in a safe subset of Python.
 
     The function may include standard python code, so long as it does
@@ -117,7 +115,7 @@ class PythonScript(Script, Historical, Cacheable):
     ) + BindingsUI.manage_options + (
         {'label': 'Test', 'action': 'ZScriptHTML_tryForm'},
         {'label': 'Proxy', 'action': 'manage_proxyForm'},
-    ) + Historical.manage_options + SimpleItem.manage_options + \
+    ) + SimpleItem.manage_options + \
         Cacheable.manage_options
 
     def __init__(self, id):
@@ -195,12 +193,6 @@ class PythonScript(Script, Historical, Cacheable):
             if name and name[0] != '*' and re.match('\w', name):
                 param_names.append(name.split('=', 1)[0].strip())
         return param_names
-
-    def manage_historyCompare(self, rev1, rev2, REQUEST,
-                              historyComparisonResults=''):
-        return PythonScript.inheritedAttribute('manage_historyCompare')(
-            self, rev1, rev2, REQUEST,
-            historyComparisonResults=html_diff(rev1.read(), rev2.read()))
 
     def __setstate__(self, state):
         Script.__setstate__(self, state)
@@ -390,9 +382,7 @@ class PythonScript(Script, Historical, Cacheable):
 
     security.declareProtected(
         'Change Python Scripts',
-        'PUT', 'manage_FTPput', 'write',
-        'manage_historyCopy',
-        'manage_beforeHistoryCopy', 'manage_afterHistoryCopy')
+        'PUT', 'manage_FTPput', 'write')
 
     def PUT(self, REQUEST, RESPONSE):
         """ Handle HTTP PUT requests """

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands =
     coverage combine
     coverage html
     coverage xml
-    coverage report --fail-under=71
+    coverage report --fail-under=72
 
 [testenv:flake8]
 basepython = python3.6


### PR DESCRIPTION
They no longer exist since Zope 4.0a2.

This is needed to run with Zope > 4.0b5. See zopefoundation/Zope#346

Supersedes #14.
Fixes #13.