### PR TITLE
Make sure a template's ``_body`` attribute is a native string in Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 4.7 (unreleased)
 ----------------
 
+- Make sure a template's ``_body`` attribute is a native string in Python 3
+  (`#30 <https://github.com/zopefoundation/Products.PythonScripts/issues/30>`_)
+
 
 4.6 (2019-04-15)
 ----------------

--- a/src/Products/PythonScripts/__init__.py
+++ b/src/Products/PythonScripts/__init__.py
@@ -29,6 +29,7 @@ __allow_access_to_unprotected_subobjects__ = 1
 
 zodbupdate_decode_dict = {
     'Products.PythonScripts.PythonScript PythonScript Python_magic': 'binary',
+    'Products.PythonScripts.PythonScript PythonScript _body': 'utf-8',
     'Products.PythonScripts.PythonScript PythonScript _code': 'binary',
 }
 


### PR DESCRIPTION
Fixes #30 

In a customer migration I am having issues with scripts that have a encoded binary string `_body` after the `zodbupdate` run and break. Just by eyeballing the code that attribute is apparently expected to be a native string.

This PR adds a `zodbupdate` policy for decoding it.