### PR TITLE
Show proper error message for not allowed identifiers.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changelog
 
 4.8 (unreleased)
 ----------------
+- Show proper error message for not allowed identifiers.
+  (`#33 <https://github.com/zopefoundation/Products.PythonScripts/issues/33>`_)
 
 
 4.7 (2019-05-21)

--- a/src/Products/PythonScripts/PythonScript.py
+++ b/src/Products/PythonScripts/PythonScript.py
@@ -125,14 +125,14 @@ class PythonScript(Script, Cacheable):
     # following identifiers are not allowed due to interaction with
     # RestrictedPython
     bad_identifiers = [
-            'context', 'container', 'script', 'traverse_subpath'
+            'context', 'container', 'script', 'traverse_subpath',
     ]
 
     def __init__(self, id):
         if id in self.bad_identifiers:
             raise ValueError(
-                "%s is not allowed as an identifier. "
-                "Please choose another name." % id
+                '%s is not allowed as an identifier. '
+                'Please choose another name.' % id,
                 )
         self.id = id
         self.ZBindings_edit(defaultBindings)

--- a/src/Products/PythonScripts/PythonScript.py
+++ b/src/Products/PythonScripts/PythonScript.py
@@ -61,12 +61,6 @@ except ImportError:  # Python 2
     Python_magic = imp.get_magic()
     del imp
 
-
-# Following identifiers are not allowed to use when instantiating
-# PythonScript due to interaction with RestrictedPython.
-BAD_IDENTIFIERS = [
-    'context', 'container', 'script', 'traverse_subpath',
-]
 # This should only be incremented to force recompilation.
 Script_magic = 4
 _log_complaint = (
@@ -129,13 +123,16 @@ class PythonScript(Script, Cacheable):
         Cacheable.manage_options
 
     def __init__(self, id):
-        if id in BAD_IDENTIFIERS:
+        self.ZBindings_edit(defaultBindings)
+        bind_names = self.getBindingAssignments().getAssignedNamesInOrder()
+        if id in bind_names:
             raise ValueError(
-                '%s is not allowed as an identifier. '
-                'Please choose another name.' % id,
+                'Following names are not allowed as identifiers, as they'
+                'have a special meaning for PythonScript: '
+                '%s.'
+                'Please choose another name.' % ', '.join(bind_names),
                 )
         self.id = id
-        self.ZBindings_edit(defaultBindings)
         self._makeFunction()
 
     security = ClassSecurityInfo()

--- a/src/Products/PythonScripts/PythonScript.py
+++ b/src/Products/PythonScripts/PythonScript.py
@@ -122,7 +122,18 @@ class PythonScript(Script, Cacheable):
     ) + SimpleItem.manage_options + \
         Cacheable.manage_options
 
+    # following identifiers are not allowed due to interaction with
+    # RestrictedPython
+    bad_identifiers = [
+            'context', 'container', 'script', 'traverse_subpath'
+    ]
+
     def __init__(self, id):
+        if id in self.bad_identifiers:
+            raise ValueError(
+                "%s is not allowed as an identifier. "
+                "Please choose another name." % id
+                )
         self.id = id
         self.ZBindings_edit(defaultBindings)
         self._makeFunction()

--- a/src/Products/PythonScripts/PythonScript.py
+++ b/src/Products/PythonScripts/PythonScript.py
@@ -61,6 +61,12 @@ except ImportError:  # Python 2
     Python_magic = imp.get_magic()
     del imp
 
+
+# Following identifiers are not allowed to use when instantiating
+# PythonScript due to interaction with RestrictedPython.
+BAD_IDENTIFIERS = [
+    'context', 'container', 'script', 'traverse_subpath',
+]
 # This should only be incremented to force recompilation.
 Script_magic = 4
 _log_complaint = (
@@ -122,14 +128,8 @@ class PythonScript(Script, Cacheable):
     ) + SimpleItem.manage_options + \
         Cacheable.manage_options
 
-    # following identifiers are not allowed due to interaction with
-    # RestrictedPython
-    bad_identifiers = [
-            'context', 'container', 'script', 'traverse_subpath',
-    ]
-
     def __init__(self, id):
-        if id in self.bad_identifiers:
+        if id in BAD_IDENTIFIERS:
             raise ValueError(
                 '%s is not allowed as an identifier. '
                 'Please choose another name.' % id,

--- a/src/Products/PythonScripts/tests/testPythonScript.py
+++ b/src/Products/PythonScripts/tests/testPythonScript.py
@@ -279,7 +279,7 @@ class TestPythonScriptErrors(PythonScriptTestBase):
         https://github.com/zopefoundation/Zope/issues/669
         """
         bad_identifiers = [
-            'context', 'container', 'script', 'traverse_subpath'
+            'context', 'container', 'script', 'traverse_subpath',
             ]
         for identifier in bad_identifiers:
             with self.assertRaises(ValueError):

--- a/src/Products/PythonScripts/tests/testPythonScript.py
+++ b/src/Products/PythonScripts/tests/testPythonScript.py
@@ -272,6 +272,19 @@ class TestPythonScriptErrors(PythonScriptTestBase):
                 func = self._newPS(defn + '\n' + asn % name)
                 self.assertRaises(TypeError, func)
 
+    def testBadIdentifiers(self):
+        """Some identifiers have to be avoided.
+
+        Background:
+        https://github.com/zopefoundation/Zope/issues/669
+        """
+        bad_identifiers = [
+            'context', 'container', 'script', 'traverse_subpath'
+            ]
+        for identifier in bad_identifiers:
+            with self.assertRaises(ValueError):
+                PythonScript(identifier)
+
 
 class TestPythonScriptGlobals(PythonScriptTestBase):
 


### PR DESCRIPTION
Due to interaction between Python(Scripts) and RestrictedPython,
following identifiers are not allowed:
- context
- container
- script
- traverse_subpath

Instead of throwing an "IndexError", now a proper error messsage
is shown.

modified:   src/Products/PythonScripts/PythonScript.py
modified:   src/Products/PythonScripts/tests/testPythonScript.py