### PR TITLE
Update configuration for isort 5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 4.12 (unreleased)
 -----------------
 
+- update configuration for version 5 of ``isort``
+
 - add a ``file`` parameter to factory function ``manage_addPythonScript``
   (`#45 <https://github.com/zopefoundation/Products.PythonScripts/issues/45>`_)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,8 +17,6 @@ known_third_party = six
 default_section = ZOPE
 line_length = 79
 lines_after_imports = 2
-not_skip =
-    __init__.py
 
 [flake8]
 no-accept-encodings = True

--- a/src/Products/PythonScripts/tests/testBindings.py
+++ b/src/Products/PythonScripts/tests/testBindings.py
@@ -107,8 +107,8 @@ class TestBindings(unittest.TestCase):
         self.connection = self.db.open()
 
     def tearDown(self):
-        from Testing.ZODButil import cleanDB
         from AccessControl.SecurityManagement import noSecurityManager
+        from Testing.ZODButil import cleanDB
         noSecurityManager()
         transaction.abort()
         self.connection.close()
@@ -189,8 +189,8 @@ class TestBindings(unittest.TestCase):
         self.assertEqual(ps(), 1)
 
     def test_bound_used_container(self):
-        from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl import Unauthorized
+        from AccessControl.SecurityManagement import newSecurityManager
         newSecurityManager(None, UnderprivilegedUser())
         root = self._makeTree()
         guarded = root._getOb('guarded')
@@ -241,8 +241,8 @@ class TestBindings(unittest.TestCase):
         self.assertEqual(ps(), 1)
 
     def test_bound_used_context(self):
-        from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl import Unauthorized
+        from AccessControl.SecurityManagement import newSecurityManager
         newSecurityManager(None, UnderprivilegedUser())
         root = self._makeTree()
         guarded = root._getOb('guarded')
@@ -303,8 +303,8 @@ class TestBindings(unittest.TestCase):
         self.assertEqual(boundless_ps(), 42)
 
     def test_bound_used_context_method_w_roles(self):
-        from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl import Unauthorized
+        from AccessControl.SecurityManagement import newSecurityManager
         newSecurityManager(None, UnderprivilegedUser())
         root = self._makeTree()
         guarded = root._getOb('guarded')

--- a/src/Products/PythonScripts/tests/testPythonScript.py
+++ b/src/Products/PythonScripts/tests/testPythonScript.py
@@ -64,8 +64,8 @@ class PythonScriptTestBase(unittest.TestCase):
 
     def setUp(self):
         from AccessControl import ModuleSecurityInfo
-        from AccessControl.SecurityInfo import _moduleSecurity
         from AccessControl.SecurityInfo import _appliedModuleSecurity
+        from AccessControl.SecurityInfo import _moduleSecurity
         self._ms_before = _moduleSecurity.copy()
         self._ams_before = _appliedModuleSecurity.copy()
         ModuleSecurityInfo('string').declarePublic('split')  # noqa: D001
@@ -73,8 +73,8 @@ class PythonScriptTestBase(unittest.TestCase):
         newSecurityManager(None, None)
 
     def tearDown(self):
-        from AccessControl.SecurityInfo import _moduleSecurity
         from AccessControl.SecurityInfo import _appliedModuleSecurity
+        from AccessControl.SecurityInfo import _moduleSecurity
         noSecurityManager()
         _moduleSecurity.clear()
         _moduleSecurity.update(self._ms_before)

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,6 @@ deps =
     flake8-debugger
     flake8-deprecated
     flake8-todo
-    flake8-isort
     mccabe
     flake8-blind-except
     flake8-commas

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ basepython = python3.6
 commands_pre =
     mkdir -p {toxinidir}/parts/flake8
 commands =
-    isort --check-only --diff --recursive {toxinidir}/src setup.py
+    isort --check-only --diff {toxinidir}/src setup.py
     - flake8 --format=html src setup.py
     flake8 src setup.py
 deps =


### PR DESCRIPTION
- two configuration options became obsolete
- removed flake8-isort, as isort is executed already as separate command
- fix sort order of some imports