### PR TITLE
Make sure "Manager" users can always modify proxy roles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 4.13 (unreleased)
 -----------------
 
+- make sure "Manager" users can always modify proxy roles
+  (`#50 <https://github.com/zopefoundation/Products.PythonScripts/issues/50>`_)
+
 - add support for Python 3.9
 
 - update configuration for version 5 of ``isort``

--- a/src/Products/PythonScripts/PythonScript.py
+++ b/src/Products/PythonScripts/PythonScript.py
@@ -37,7 +37,6 @@ from AccessControl.ZopeGuards import get_safe_globals
 from AccessControl.ZopeGuards import guarded_getattr
 from Acquisition import aq_parent
 from App.Common import package_home
-from App.Dialogs import MessageDialog
 from App.special_dtml import DTMLFile
 from OFS.Cache import Cacheable
 from OFS.History import Historical
@@ -398,15 +397,16 @@ class PythonScript(Script, Historical, Cacheable):
     @requestmethod('POST')
     def manage_proxy(self, roles=(), REQUEST=None):
         """Change Proxy Roles"""
-        self._validateProxy(roles)
-        self._validateProxy()
+        user = getSecurityManager().getUser()
+        if 'Manager' not in user.getRolesInContext(self):
+            self._validateProxy(roles)
+            self._validateProxy()
         self.ZCacheable_invalidate()
         self._proxy_roles = tuple(roles)
         if REQUEST:
-            return MessageDialog(
-                title='Success!',
-                message='Your changes have been saved',
-                action='manage_main')
+            msg = 'Proxy roles changed.'
+            return self.manage_proxyForm(manage_tabs_message=msg,
+                                         management_view='Proxy')
 
     security.declareProtected(  # NOQA: D001
         change_python_scripts,

--- a/src/Products/PythonScripts/tests/testPythonScript.py
+++ b/src/Products/PythonScripts/tests/testPythonScript.py
@@ -19,8 +19,11 @@ import unittest
 import warnings
 
 import six
+from six.moves.urllib.error import HTTPError
 
+import zExceptions
 import Zope2
+from AccessControl.Permissions import change_proxy_roles
 from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import noSecurityManager
 from OFS.Folder import Folder
@@ -523,3 +526,83 @@ class PythonScriptBrowserTests(FunctionalTestCase):
         self.browser.getControl('Upload File').click()
 
         assert 'Saved changes.' in self.browser.contents
+
+    def test_PythonScript_proxyroles_manager(self):
+        test_role = 'Test Role'
+        self.app._addRole(test_role)
+
+        # Test the original state
+        self.assertFalse(self.app.py_script.manage_haveProxy(test_role))
+
+        # Go to the "Proxy" ZMI tab, grab the Proxy Roles select box,
+        # select the new role and submit
+        self.browser.open('http://localhost/py_script/manage_proxyForm')
+        roles_selector = self.browser.getControl(name='roles:list')
+        testrole_option = roles_selector.getControl(test_role)
+        self.assertFalse(testrole_option.selected)
+        testrole_option.selected = True
+        self.browser.getControl('Save Changes').click()
+
+        # The Python Script should now have a proxy role set
+        self.assertTrue(self.app.py_script.manage_haveProxy(test_role))
+
+    def test_PythonScript_proxyroles_nonmanager(self):
+        # This test checks an unusual configuration where roles other than
+        # Manager are allowed to change proxy roles.
+        proxy_form_url = 'http://localhost/py_script/manage_proxyForm'
+        test_role = 'Test Role'
+        self.app._addRole(test_role)
+        test_role_2 = 'Unprivileged Role'
+        self.app._addRole(test_role_2)
+        self.app.manage_permission(change_proxy_roles, ['Manager', test_role])
+
+        # Add some test users
+        uf = self.app.acl_users
+        uf.userFolderAddUser('privileged', 'priv', [test_role], [])
+        uf.userFolderAddUser('peon', 'unpriv', [test_role_2], [])
+
+        # Test the original state
+        self.assertFalse(self.app.py_script.manage_haveProxy(test_role))
+        self.assertFalse(self.app.py_script.manage_haveProxy(test_role_2))
+
+        # Attempt as unprivileged user will fail both in the browser and
+        # from trusted code
+        self.browser.login('peon', 'unpriv')
+        with self.assertRaises(HTTPError):
+            self.browser.open(proxy_form_url)
+
+        newSecurityManager(None, uf.getUser('peon'))
+        with self.assertRaises(zExceptions.Forbidden):
+            self.app.py_script.manage_proxy(roles=(test_role,))
+        self.assertFalse(self.app.py_script.manage_haveProxy(test_role))
+
+        # Now log in as privileged user and try to set a proxy role
+        # the privileged user does not have. This must fail.
+        self.browser.login('privileged', 'priv')
+        self.browser.open(proxy_form_url)
+        roles_selector = self.browser.getControl(name='roles:list')
+        bad_option = roles_selector.getControl(test_role_2)
+        self.assertFalse(bad_option.selected)
+        bad_option.selected = True
+        with self.assertRaises(HTTPError):
+            self.browser.getControl('Save Changes').click()
+        self.assertFalse(self.app.py_script.manage_haveProxy(test_role_2))
+
+        newSecurityManager(None, uf.getUser('privileged'))
+        with self.assertRaises(zExceptions.Forbidden):
+            self.app.py_script.manage_proxy(roles=(test_role_2,))
+        self.assertFalse(self.app.py_script.manage_haveProxy(test_role_2))
+
+        # Trying again as privileged user with a proxy role the user has
+        self.browser.open(proxy_form_url)
+        roles_selector = self.browser.getControl(name='roles:list')
+        testrole_option = roles_selector.getControl(test_role)
+        self.assertFalse(testrole_option.selected)
+        testrole_option.selected = True
+        self.browser.getControl('Save Changes').click()
+
+        # The Python Script should now have a proxy role set
+        self.assertTrue(self.app.py_script.manage_haveProxy(test_role))
+
+        # Cleanup
+        noSecurityManager()


### PR DESCRIPTION
Fixes #50 

It makes no sense that "Manager" users can effectively be prevented from modifying a Python Script with a proxy role the Manager-level user doesn't have. This PR circumvents the proxy role check for Manager users.