### PR TITLE
ZMI: use `code` class for params

### DIFF
--- a/src/Products/PythonScripts/www/pyScriptEdit.dtml
+++ b/src/Products/PythonScripts/www/pyScriptEdit.dtml
@@ -16,7 +16,7 @@
 			<div class="form-group row ">
 				<label for="params" class="form-label col-sm-3 col-md-2">Parameter List</label>
 				<div class="col-sm-9 col-md-10">
-					<input id="params" class="form-control" type="text" name="params" value="&dtml-params;" />
+					<input id="params" class="form-control code" type="text" name="params" value="&dtml-params;" />
 				</div>
 			</div>
 		</dtml-with>


### PR DESCRIPTION
Because parameters are python code, it's a bit more convenient to view and edit them with a monospace font

before 

![image](https://user-images.githubusercontent.com/521510/224024118-0e38eb3b-fd2f-43de-9584-f27070f04265.png)


after 

![image](https://user-images.githubusercontent.com/521510/224023989-94dc5020-486e-41d2-ac6f-b1ae35eb4fa3.png)
