### PR TITLE
Fix behavior when uploading no file in `Zope >= 5.8.1`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 5.1 (unreleased)
 ----------------
 
+- Fix behavior when uploading no file in ``Zope >= 5.8.1``.
+
 
 5.0 (2023-02-01)
 ----------------

--- a/src/Products/PythonScripts/PythonScript.py
+++ b/src/Products/PythonScripts/PythonScript.py
@@ -179,12 +179,12 @@ class PythonScript(Script, Historical, Cacheable):
         if self.wl_isLocked():
             raise ResourceLockedError('The script is locked via WebDAV.')
 
+        if not file:
+            return self.ZPythonScriptHTML_editForm(
+                self, REQUEST,
+                manage_tabs_message='No file specified',
+                manage_tabs_type='warning')
         if not isinstance(file, str):
-            if not file:
-                return self.ZPythonScriptHTML_editForm(
-                    self, REQUEST,
-                    manage_tabs_message='No file specified',
-                    manage_tabs_type='warning')
             file = file.read()
 
         self.write(file)


### PR DESCRIPTION
The test assuring an error message when `Upload file` is clicked but no file is chosen failed since the release of Zope 5.8.1., because `file` is now an empty string.

See https://github.com/zopefoundation/Products.PythonScripts/actions/runs/4460541421/jobs/7833754724

The changes work with 5.8.0 and 5.8.1.