### PR TITLE
Show Python Script source code in tracebacks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changelog
 - Drop support for Python 3.7.
 
 - Show Python Scripts source code in tracebacks.
-
+  `#64 <https://github.com/zopefoundation/Products.PythonScripts/issues/64>`_
 
 5.0 (2023-02-01)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Changelog
 
 - Drop support for Python 3.7.
 
+- Show Python Scripts source code in tracebacks.
+
 
 5.0 (2023-02-01)
 ----------------

--- a/src/Products/PythonScripts/PythonScript.py
+++ b/src/Products/PythonScripts/PythonScript.py
@@ -102,6 +102,7 @@ def manage_addPythonScript(self, id, title='', file=None, REQUEST=None,
 class PythonScriptLoader(importlib.abc.Loader):
     """PEP302 loader to display source code in tracebacks
     """
+
     def __init__(self, source):
         self._source = source
 


### PR DESCRIPTION
Expose a `__loader__` in globals so that linecache module is able to use it to display the source code.

This requires changing the "filename" used when compiling function, because linecache uses code.co_filename as a cache key, so it's necessary that each python script use a different filename.

Fixes #64